### PR TITLE
cmd/dep: replace `len(x)<=0` with `len(x)==0` (#2031)

### DIFF
--- a/cmd/dep/init.go
+++ b/cmd/dep/init.go
@@ -74,7 +74,7 @@ func (cmd *initCommand) Run(ctx *dep.Ctx, args []string) error {
 	}
 
 	var root string
-	if len(args) <= 0 {
+	if len(args) == 0 {
 		root = ctx.WorkingDir
 	} else {
 		root = args[0]


### PR DESCRIPTION
Length never returns negative values.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>

<!--
Work-in-progress PRs are welcome as a way to get early feedback - just prefix
the title with [WIP].

Add the change in the changelog (except for test changes and docs updates).
Please edit CHANGELOG.md and add the change under the appropriate category (NEW
FEATURES, IMPROVEMENTS & BUG FIXES) along with the PR number.
-->

### What does this do / why do we need it?

### What should your reviewer look out for in this PR?

### Do you need help or clarification on anything?

### Which issue(s) does this PR fix?

<!--

fixes #
fixes #

-->
